### PR TITLE
Allow overriding IP/hostname & Remove SIP domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A [SIP over WebSocket](https://datatracker.ietf.org/doc/html/rfc7118) - [SIP](ht
 
 This gateway allows any SIP user of your Fritz!Box to perform calls with SIP over WebSocket, which is unsupported by the Fritz!Box.
 
+Please note that this might also work for other SIP servers, however this container is developed for and tested with AVM Fritz!Boxes.
+
 ## Important Information
 
 To connect to the SIP over WebSocket from mobile clients like Android & iOS, it is required that you use TLS.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This gateway allows any SIP user of your Fritz!Box to perform calls with SIP ove
 
 ## Important Information
 
-The domain of the SIP server is “hard-coded” to `fritz.box`.
-
 To connect to the SIP over WebSocket from mobile clients like Android & iOS, it is required that you use TLS.
 webrtc-sip-gw will enable it’s internal TLS by default and therefore requires a certificate, but you can disable the internal TLS if you want to use a proxy like nginx instead.
+
+The Docker container will automatically configure IP address and hostname/domain name for the webrtc-sip-gw, however in some cases (e.g. with multiplce NICs) this auto-configuration may pick the "wrong" settings.
+Set the `MY_IP` and `MY_DOMAIN` environment variables in the `environment` section of the docker-compose file to override the auto-configured values.
 
 ### Internal TLS
 
@@ -42,6 +43,11 @@ SIP over WebSocket is exposed on TCP ports 8090 (unsecured) and, if internal TLS
 Additionally, UDP ports 23400-23500 are exposed by rtpengine.
 
 If you use any firewall, these ports need to be open!
+For ufw, you can open these ports using the following command:
+
+```bash
+ufw allow in from any to any port 23400:23500 proto udp comment "webrtc-sip-gw"
+```
 
 ## Container Setup Guide
 

--- a/config/kamailio/kamctlrc
+++ b/config/kamailio/kamctlrc
@@ -7,7 +7,7 @@
 # will use their internal default values.
 
 ## your SIP domain
-SIP_DOMAIN=MY_SIP_DOMAIN
+SIP_DOMAIN=FILL_SIP_DOMAIN
 
 ## chrooted directory
 # $CHROOT_DIR="/path/to/chrooted/directory"

--- a/config/kamailio/kamctlrc
+++ b/config/kamailio/kamctlrc
@@ -7,7 +7,7 @@
 # will use their internal default values.
 
 ## your SIP domain
-SIP_DOMAIN=fritz.box
+SIP_DOMAIN=MY_SIP_DOMAIN
 
 ## chrooted directory
 # $CHROOT_DIR="/path/to/chrooted/directory"

--- a/config/kamailio/kamctlrc
+++ b/config/kamailio/kamctlrc
@@ -7,7 +7,7 @@
 # will use their internal default values.
 
 ## your SIP domain
-SIP_DOMAIN=FILL_SIP_DOMAIN
+# SIP_DOMAIN=FILL_SIP_DOMAIN
 
 ## chrooted directory
 # $CHROOT_DIR="/path/to/chrooted/directory"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -e
 
-#MY_IP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
-MY_IP=$(hostname -I | awk '{print $1}')
-MY_DOMAIN=$(hostname)
+MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
+MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@ set -e
 
 MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
 MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
-SIP_DOMAIN=${SIP_DOMAIN:=fritz.box}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg
@@ -11,8 +10,6 @@ sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /healthcheck.sh
 
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamailio.cfg
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamctlrc
-
-sed -i -e "s/FILL_SIP_DOMAIN/${SIP_DOMAIN}/g" /etc/kamailio/kamctlrc
 
 # Allow disabling TLS by setting the TLS_DISABLE env variable to true
 if [ "$TLS_DISABLE" == true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
 MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
-MY_SIP_DOMAIN=${FILL_SIP_DOMAIN:=fritz.box}
+SIP_DOMAIN=${SIP_DOMAIN:=fritz.box}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
 MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
+MY_SIP_DOMAIN=${FILL_SIP_DOMAIN:=fritz.box}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg
@@ -10,6 +11,8 @@ sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /healthcheck.sh
 
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamailio.cfg
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamctlrc
+
+sed -i -e "s/FILL_SIP_DOMAIN/${SIP_DOMAIN}/g" /etc/kamailio/kamctlrc
 
 # Allow disabling TLS by setting the TLS_DISABLE env variable to true
 if [ "$TLS_DISABLE" == true ]; then


### PR DESCRIPTION
- Allows overriding the automatically configured IP and hostname/local domain by using environment variables `MY_IP` and `MY_DOMAIN`.
- Removes/Disables `SIP_DOMAIN` in kamctrlc as it is not needed.
- Provides sample command to open required ports in ufw firewall.