### PR TITLE
Major container refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 .vscode
-/ssl
+ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,40 @@
 FROM debian:12-slim
 
-# Basic build-time metadata as defined at http://label-schema.org
-LABEL org.label-schema.docker.dockerfile="/Dockerfile" \
-  org.label-schema.license="MIT" \
-  org.label-schema.name="WebRTC SIP Gateway" \
-  org.label-schema.description="A WebRTC-SIP gateway for Fritzbox based on Kamailio and rtpengine" \
-  org.label-schema.url="https://github.com/florian-h05/webrtc-sip-gw" \
-  org.label-schema.vcs-type="Git" \
-  org.label-schema.vcs-url="https://github.com/florian-h05/webrtc-sip-gw.git" \
-  maintainer="Florian Hotze <florianh_dev@icloud.com>"
+# Create users and groups
+RUN useradd -u 1500 --no-create-home -s /bin/false rtpengine && \
+    useradd -u 1501 --no-create-home -s /bin/false kamailio
 
-# Install requirements
+# Install dependencies and useful tools
 RUN \
-  apt-get update \
-  && apt-get install -y --no-install-recommends supervisor nano
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y supervisor nano
 
 # Install Kamailio and rtpengine
 RUN \
-  apt-get update \
-  && apt-get install -y --no-install-recommends rtpengine \
-  && apt-get install -y --no-install-recommends kamailio kamailio-websocket-modules kamailio-tls-modules kamailio-presence-modules kamailio-outbound-modules
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y rtpengine && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y kamailio kamailio-websocket-modules kamailio-tls-modules kamailio-presence-modules kamailio-outbound-modules
 
-# Do not persist /tmp in a volume to allow clearing it by restarting the container
-# VOLUME ["/tmp"]
+# Copy entrypoint and healthcheck scripts
+COPY ./entrypoint /entrypoint
+COPY ./healthcheck /healthcheck
 
-# Expose rtpengine UDP ports
-EXPOSE 23400-23500/udp
-# Expose Kamailio TCP ports for unsecured and secured SIP over WebSocket
-EXPOSE 8090 4443
-
-# Set healthcheck
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD bash /healthcheck.sh
-
-COPY ./entrypoint.sh /entrypoint.sh
-COPY ./healthcheck.sh /healthcheck.sh
 # Copy configuration
 COPY ./config/supervisor-rtpengine.conf /etc/supervisor/conf.d/rtpengine.conf
 COPY ./config/supervisor-kamailio.conf /etc/supervisor/conf.d/kamailio.conf
-COPY ./config/rtpengine/rtpengine.conf /etc/rtpengine/rtpengine.conf
-COPY ./config/kamailio/kamailio.cfg /etc/kamailio/kamailio.cfg
-COPY ./config/kamailio/kamctlrc /etc/kamailio/kamctlrc
-COPY ./config/kamailio/tls.cfg /etc/kamailio/tls.cfg
+COPY --chown=1500 ./config/rtpengine/rtpengine.conf /etc/rtpengine/rtpengine.conf
+COPY --chown=1501 ./config/kamailio/kamailio.cfg /etc/kamailio/kamailio.cfg
+COPY --chown=1501 ./config/kamailio/kamctlrc /etc/kamailio/kamctlrc
+COPY --chown=1501 ./config/kamailio/tls.cfg /etc/kamailio/tls.cfg
 
-ENTRYPOINT ["/entrypoint.sh"]
+# Create necessary directories
+RUN mkdir -p /var/run/rtpengine && \
+    chown 1500 /var/run/rtpengine && \
+    mkdir -p /var/run/kamailio && \
+    chown 1501 /var/run/kamailio
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD bash /healthcheck
+
+ENTRYPOINT ["/entrypoint"]
 
 CMD ["/usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf -u root"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p /var/run/rtpengine && \
     mkdir -p /var/run/kamailio && \
     chown 1501 /var/run/kamailio
 
-HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD bash /healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD sh /healthcheck
 
 ENTRYPOINT ["/entrypoint"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,16 +22,16 @@ COPY ./healthcheck /healthcheck
 # Copy configuration
 COPY ./config/supervisor-rtpengine.conf /etc/supervisor/conf.d/rtpengine.conf
 COPY ./config/supervisor-kamailio.conf /etc/supervisor/conf.d/kamailio.conf
-COPY --chown=1500 ./config/rtpengine/rtpengine.conf /etc/rtpengine/rtpengine.conf
-COPY --chown=1501 ./config/kamailio/kamailio.cfg /etc/kamailio/kamailio.cfg
-COPY --chown=1501 ./config/kamailio/kamctlrc /etc/kamailio/kamctlrc
-COPY --chown=1501 ./config/kamailio/tls.cfg /etc/kamailio/tls.cfg
+COPY --chown=rtpengine:rtpengine ./config/rtpengine/rtpengine.conf /etc/rtpengine/rtpengine.conf
+COPY --chown=kamailio:kamailio ./config/kamailio/kamailio.cfg /etc/kamailio/kamailio.cfg
+COPY --chown=kamailio:kamailio ./config/kamailio/kamctlrc /etc/kamailio/kamctlrc
+COPY --chown=kamailio:kamailio ./config/kamailio/tls.cfg /etc/kamailio/tls.cfg
 
 # Create necessary directories
 RUN mkdir -p /var/run/rtpengine && \
-    chown 1500 /var/run/rtpengine && \
+    chown rtpengine:rtpengine /var/run/rtpengine && \
     mkdir -p /var/run/kamailio && \
-    chown 1501 /var/run/kamailio
+    chown kamailio:kamailio /var/run/kamailio
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD sh /healthcheck
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ OpenSSL can be told to generate a 2048 bit long RSA key and a certificate that i
 - Replace `<IP-ADDRESS>` with your server's IP address.
 - Replace `<ADDITIONAL-HOSTNAME>` with another hostname the certificate should be valid for, or delete `,DNS:<ADDITIONAL-HOSTNAME>`.
 ```shell
-openssl req -x509 -nodes -days 825 -newkey rsa:2048 -addext 'subjectAltName=IP:<IP-ADDRESS>,DNS:<ADDITIONAL-HOSTNAME>' -addext 'keyUsage = digitalSignature,keyEncipherment' -addext 'extendedKeyUsage = serverAuth' -keyout ./ssl/sipgw.key -out ./ssl/sipgw.crt
+openssl req -x509 -nodes -days 825 -newkey rsa:2048 -addext 'subjectAltName=IP:<IP-ADDRESS>,DNS:<ADDITIONAL-HOSTNAME>' -addext 'keyUsage = digitalSignature,keyEncipherment' -addext 'extendedKeyUsage = serverAuth' -keyout ./ssl/privkey.pem -out ./ssl/fullchain.pem
 ```
 
 This certificate follows the [Requirements for trusted certificates in iOS 13 and macOS 10.15](https://support.apple.com/en-us/HT210176).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add this `location` block to a valid `server` configuration:
 
 SIP over WebSocket is exposed on TCP ports 8080 (unsecured) and, if internal TLS is enabled, 8443 (secured).
 Additionally, UDP ports 23400 to 23500 are exposed by _rtpengine_.
-You can overwrite the WebSocker ports by setting the `MY_WS_PORT` and `MY_WSS_PORT` environment variables in the [`docker-compose.yml`](docker-compose.yml) file.
+You can overwrite the WebSocker ports by setting the `WS_PORT` and `WSS_PORT` environment variables in the [`docker-compose.yml`](docker-compose.yml) file.
 
 If you use any firewall on the Docker host, the above ports need to be open!
 For ufw, you can open these ports using the following command:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Unless internal TLS is not explicitly disabled, TLS certificate and private key 
 - certificate: `/etc/ssl/fullchain.pem`
 - private key: `/etc/ssl/privkey.pem`
 
-The provided `docker-compose` file includes mounts for these two files.
+The provided [`docker-compose.yml`](docker-compose.yml) file mounts the `ssl` directory properly into the container.
 
 ### nginx Reverse Proxy
 
@@ -42,21 +42,24 @@ Add this `location` block to a valid `server` configuration:
 
 ### Ports
 
-SIP over WebSocket is exposed on TCP ports 8090 (unsecured) and, if internal TLS is enabled, 4443 (secured).
+SIP over WebSocket is exposed on TCP ports 8080 (unsecured) and, if internal TLS is enabled, 8443 (secured).
 Additionally, UDP ports 23400 to 23500 are exposed by _rtpengine_.
+You can overwrite the WebSocker ports by setting the `MY_WS_PORT` and `MY_WSS_PORT` environment variables in the [`docker-compose.yml`](docker-compose.yml) file.
 
-If you use any firewall, these ports need to be open!
+If you use any firewall on the Docker host, the above ports need to be open!
 For ufw, you can open these ports using the following command:
 
 ```bash
+ufw allow in from any to any port 8080 proto tcp comment "webrtc-sip-gw WebSocket transport"
+ufw allow in from any to any port 8443 proto tcp comment "webrtc-sip-gw WebSocket Secure transport"
 ufw allow in from any to any port 23400:23500 proto udp comment "webrtc-sip-gw UDP transport"
 ```
 
 ### Platform Support
 
-webrtc-sip-gw is built for Linux on `amd64`, `arm64` and `armv7l`, so it should run on most modern Linux machines, including Raspberry Pis.
+webrtc-sip-gw is built for Linux on `amd64` and  `arm64`, so it should run on most modern Linux machines, including Raspberry Pis.
 
-I have tested it on `amd64`, in case someone can test on `arm64` or `armv7`, please report (open an issue) how it works.
+`amd64` has been tested in production on a x86_64 Debian 12 host, `arm64` has been validated to start on QEMU emulation.
 
 ## Container Setup Guide
 
@@ -64,7 +67,7 @@ I have tested it on `amd64`, in case someone can test on `arm64` or `armv7`, ple
 
 Create a new directory on your Docker host and place the [docker-compose.yml](/docker-compose.yml) there.
 
-If you want to disable the internal TLS, set the value of the `TLS_DISABLE` environment variable in the `docker-compose` file to `true`:
+If you want to disable the internal TLS, set the value of the `TLS_DISABLE` environment variable in the [`docker-compose.yml`](docker-compose.yml) file to `true`:
 
 Unless you have not explicitly disabled TLS:
 
@@ -128,7 +131,7 @@ ERROR: rtpengine [rtpengine.c:2788]: rtpp_test(): proxy did not respond to ping
 
 #### Install & Trust Certificate on Clients
 
-Copy the `sipgw.crt` (only this file, not the key!) to your clients and open the file.
+Copy the `fullchain.pem` certificate file to your clients and open the file.
 
 On Android and Windows, a popup with a certificate installation wizard should open up.
 
@@ -139,8 +142,8 @@ Visit the settings as told and proceed.
 
 Using the [`oh-sipclient`](https://openhab.org/docs/ui/components/oh-sipclient.html) component or widget, use the following configuration:
 
-- `websocketUrl`: `wss://YOUR-DOCKER-HOST:4443`
-- `domain`: `fritz.box`
+- `websocketUrl`: `wss://YOUR-DOCKER-HOST:8443`
+- `domain`: the domain of your SIP server, e.g. `fritz.box`
 - `username`: any valid SIP user in your Fritz!Box
 - `password`: password of your valid SIP user
 

--- a/config/kamailio/kamailio.cfg
+++ b/config/kamailio/kamailio.cfg
@@ -6,8 +6,8 @@
 ##!define WITH_BRIDGE_ON_FAIL
 
 #!substdef "!MY_SIP_PORT!5060!g"
-#!substdef "!MY_WS_PORT!8090!g"
-#!substdef "!MY_WSS_PORT!4443!g"
+#!substdef "!MY_WS_PORT!FILL_MY_WS_PORT!g"
+#!substdef "!MY_WSS_PORT!FILL_MY_WSS_PORT!g"
 
 #!substdef "!MY_IP4_ADDR!FILL_MY_IP!g"
 #!substdef "!MY_DOMAIN!FILL_MY_DOMAIN!g"

--- a/config/kamailio/kamailio.cfg
+++ b/config/kamailio/kamailio.cfg
@@ -6,8 +6,8 @@
 ##!define WITH_BRIDGE_ON_FAIL
 
 #!substdef "!MY_SIP_PORT!5060!g"
-#!substdef "!MY_WS_PORT!FILL_MY_WS_PORT!g"
-#!substdef "!MY_WSS_PORT!FILL_MY_WSS_PORT!g"
+#!substdef "!MY_WS_PORT!FILL_WS_PORT!g"
+#!substdef "!MY_WSS_PORT!FILL_WSS_PORT!g"
 
 #!substdef "!MY_IP4_ADDR!FILL_MY_IP!g"
 #!substdef "!MY_DOMAIN!FILL_MY_DOMAIN!g"

--- a/config/kamailio/tls.cfg
+++ b/config/kamailio/tls.cfg
@@ -6,8 +6,8 @@
 method = TLSv1.2+
 verify_certificate = no
 require_certificate = no
-private_key = /etc/ssl/privkey.pem
-certificate = /etc/ssl/fullchain.pem
+private_key = /etc/ssl/kamailio/privkey.pem
+certificate = /etc/ssl/kamailio/fullchain.pem
 
 [client:default]
 method = TLSv1.2+

--- a/config/supervisor-kamailio.conf
+++ b/config/supervisor-kamailio.conf
@@ -3,7 +3,7 @@ directory=/var/run/kamailio                        ; Working directory for Kamai
 command=/usr/sbin/kamailio -E -DD -P /var/run/kamailio/kamailio.pid -f /etc/kamailio/kamailio.cfg
                                                    ; Run Kamailio in foreground with debug and pidfile
 
-user=1501                                          ; Run as kamailio user, currently disabled as not working with certificates
+user=kamailio                                      ; Run as kamailio user
 
 redirect_stderr=true                               ; Merge stderr into stdout
 stdout_logfile=/dev/fd/1                           ; Send stdout logs to Docker stdout

--- a/config/supervisor-kamailio.conf
+++ b/config/supervisor-kamailio.conf
@@ -3,7 +3,7 @@ directory=/var/run/kamailio                        ; Working directory for Kamai
 command=/usr/sbin/kamailio -E -DD -P /var/run/kamailio/kamailio.pid -f /etc/kamailio/kamailio.cfg
                                                    ; Run Kamailio in foreground with debug and pidfile
 
-;user=1501                                         ; Run as kamailio user, currently disabled as not working with certificates
+user=1501                                          ; Run as kamailio user, currently disabled as not working with certificates
 
 redirect_stderr=true                               ; Merge stderr into stdout
 stdout_logfile=/dev/fd/1                           ; Send stdout logs to Docker stdout

--- a/config/supervisor-kamailio.conf
+++ b/config/supervisor-kamailio.conf
@@ -1,12 +1,20 @@
 [program:kamailio]
-directory=/tmp
-command=/usr/sbin/kamailio -E -DD -P /run/kamailio/kamailio.pid -f /etc/kamailio/kamailio.cfg
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-# The total number of seconds which the program needs to stay running after a startup to consider the start successful
-startsecs=5
-# The relative priority of the program in the start and shutdown ordering.
-# Lower priorities indicate programs that start first and shut down last at startup and when aggregate commands are used in various clients (e.g. "start all"/"stop all").
-# Higher priorities indicate programs that start last and shut down first.
-priority=5
+directory=/var/run/kamailio                        ; Working directory for Kamailio
+command=/usr/sbin/kamailio -E -DD -P /var/run/kamailio/kamailio.pid -f /etc/kamailio/kamailio.cfg
+                                                   ; Run Kamailio in foreground with debug and pidfile
+
+;user=1501                                         ; Run as kamailio user, currently disabled as not working with certificates
+
+redirect_stderr=true                               ; Merge stderr into stdout
+stdout_logfile=/dev/fd/1                           ; Send stdout logs to Docker stdout
+stdout_logfile_maxbytes=0                          ; Disable log file rotation by size
+stdout_logfile_backups=0                           ; Disable old log backups
+
+startsecs=5                                        ; Number of seconds process must stay running to consider start successful
+autorestart=true                                   ; Restart if the process crashes unexpectedly
+startretries=3                                     ; Number of restart attempts before giving up
+exitcodes=0                                        ; Exit codes considered normal (no restart)
+
+priority=100                                       ; Start order priority (lower means earlier start)
+numprocs=1                                         ; Only one instance of the program should run
+process_name=%(program_name)s                      ; Use program name as process name (useful for scaling/debugging)

--- a/config/supervisor-rtpengine.conf
+++ b/config/supervisor-rtpengine.conf
@@ -1,12 +1,20 @@
 [program:rtpengine]
-directory=/tmp
-command=/usr/bin/rtpengine -f -E --no-log-timestamps --pidfile /run/rtpengine-daemon.pid --config-file /etc/rtpengine/rtpengine.conf --table -1
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-# The total number of seconds which the program needs to stay running after a startup to consider the start successful
-startsecs=5
-# The relative priority of the program in the start and shutdown ordering.
-# Lower priorities indicate programs that start first and shut down last at startup and when aggregate commands are used in various clients (e.g. "start all"/"stop all").
-# Higher priorities indicate programs that start last and shut down first.
-priority=1
+directory=/var/run/rtpengine                      ; Set working directory for the program
+command=/usr/bin/rtpengine -f -E --no-log-timestamps --pidfile /var/run/rtpengine/rtpengine-daemon.pid --config-file /etc/rtpengine/rtpengine.conf --table -1
+                                                  ; Command to start the rtpengine daemon with options
+
+user=1500                                         ; Run as rtpengine user
+
+redirect_stderr=true                              ; Merge stderr into stdout
+stdout_logfile=/dev/fd/1                          ; Send stdout logs to Docker stdout
+stdout_logfile_maxbytes=0                         ; Disable log file rotation by size (infinite)
+stdout_logfile_backups=0                          ; Disable old log file backups
+
+startsecs=5                                       ; Number of seconds process must stay running to consider start successful
+autorestart=true                                  ; Automatically restart if process exits unexpectedly
+startretries=3                                    ; Number of restart attempts before giving up
+exitcodes=0                                       ; Exit codes considered "expected" (no restart)
+
+priority=10                                       ; Start order priority (lower means earlier start)
+numprocs=1                                        ; Only one instance of the program should run
+process_name=%(program_name)s                     ; Use program name as process name (useful for scaling/debugging)

--- a/config/supervisor-rtpengine.conf
+++ b/config/supervisor-rtpengine.conf
@@ -3,7 +3,7 @@ directory=/var/run/rtpengine                      ; Set working directory for th
 command=/usr/bin/rtpengine -f -E --no-log-timestamps --pidfile /var/run/rtpengine/rtpengine-daemon.pid --config-file /etc/rtpengine/rtpengine.conf --table -1
                                                   ; Command to start the rtpengine daemon with options
 
-user=1500                                         ; Run as rtpengine user
+user=rtpengine                                    ; Run as rtpengine user
 
 redirect_stderr=true                              ; Merge stderr into stdout
 stdout_logfile=/dev/fd/1                          ; Send stdout logs to Docker stdout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   webrtc-sip-gw:
     container_name: webrtc-sip-gw
@@ -7,7 +5,6 @@ services:
     restart: always
     network_mode: host
     volumes:
-     - ./ssl/sipgw.key:/etc/ssl/privkey.pem:ro # Can be left out when TLS is disabled
-     - ./ssl/sipgw.crt:/etc/ssl/fullchain.pem:ro # Can be left out when TLS is disabled
+     - ./ssl:/etc/ssl/kamailio # Can be left out when TLS is disabled
     environment:
      - TLS_DISABLE=false # Optional, defaults to false

--- a/entrypoint
+++ b/entrypoint
@@ -3,8 +3,8 @@ set -e
 
 MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
 MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
-MY_WS_PORT=${MY_WS_PORT:=8080}
-MY_WSS_PORT=${MY_WSS_PORT:=8443}
+WS_PORT=${WS_PORT:=8080}
+WSS_PORT=${WSS_PORT:=8443}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg
@@ -13,8 +13,8 @@ sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /healthcheck
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamailio.cfg
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamctlrc
 
-sed -i -e "s/FILL_MY_WS_PORT/${MY_WS_PORT}/g" /etc/kamailio/kamailio.cfg
-sed -i -e "s/FILL_MY_WSS_PORT/${MY_WSS_PORT}/g" /etc/kamailio/kamailio.cfg
+sed -i -e "s/FILL_WS_PORT/${WS_PORT}/g" /etc/kamailio/kamailio.cfg
+sed -i -e "s/FILL_WSS_PORT/${WSS_PORT}/g" /etc/kamailio/kamailio.cfg
 
 # Allow disabling TLS by setting the TLS_DISABLE env variable to true
 if [ "$TLS_DISABLE" = "true" ] || [ "$TLS_DISABLE" = "1" ]

--- a/entrypoint
+++ b/entrypoint
@@ -22,7 +22,7 @@ then
   sed -i -e "s/#!define WITH_TLS/##!define WITH_TLS/" /etc/kamailio/kamailio.cfg
 else
   chown kamailio:kamailio -R /etc/ssl/kamailio
-  chmod 755 -R /etc/ssl/kamailio
+  chmod 755 /etc/ssl/kamailio
   chmod 744 /etc/ssl/kamailio/fullchain.pem
   chmod 700 /etc/ssl/kamailio/privkey.pem
 fi

--- a/entrypoint
+++ b/entrypoint
@@ -1,19 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 MY_IP=${MY_IP:=$(hostname -I | awk '{print $1}')}
 MY_DOMAIN=${MY_DOMAIN:=$(hostname)}
+MY_WS_PORT=${MY_WS_PORT:=8080}
+MY_WSS_PORT=${MY_WSS_PORT:=8443}
 
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/rtpengine/rtpengine.conf
 sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /etc/kamailio/kamailio.cfg
-sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /healthcheck.sh
+sed -i -e "s/FILL_MY_IP/${MY_IP}/g" /healthcheck
 
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamailio.cfg
 sed -i -e "s/FILL_MY_DOMAIN/${MY_DOMAIN}/g" /etc/kamailio/kamctlrc
 
+sed -i -e "s/FILL_MY_WS_PORT/${MY_WS_PORT}/g" /etc/kamailio/kamailio.cfg
+sed -i -e "s/FILL_MY_WSS_PORT/${MY_WSS_PORT}/g" /etc/kamailio/kamailio.cfg
+
 # Allow disabling TLS by setting the TLS_DISABLE env variable to true
-if [ "$TLS_DISABLE" == true ]; then
+if [ "$TLS_DISABLE" = true ]
+then
   sed -i -e "s/#!define WITH_TLS/##!define WITH_TLS/" /etc/kamailio/kamailio.cfg
+else
+  chown 1501:1501 -R /etc/ssl/kamailio
+  chmod 655 -R /etc/ssl/kamailio
+  chmod 644 /etc/ssl/kamailio/fullchain.pem
+  chmod 600 /etc/ssl/kamailio/privkey.pem
 fi
 
 # shellcheck disable=SC2068

--- a/entrypoint
+++ b/entrypoint
@@ -21,7 +21,7 @@ if [ "$TLS_DISABLE" = "true" ] || [ "$TLS_DISABLE" = "1" ]
 then
   sed -i -e "s/#!define WITH_TLS/##!define WITH_TLS/" /etc/kamailio/kamailio.cfg
 else
-  chown 1501:1501 -R /etc/ssl/kamailio
+  chown kamailio:kamailio -R /etc/ssl/kamailio
   chmod 755 -R /etc/ssl/kamailio
   chmod 744 /etc/ssl/kamailio/fullchain.pem
   chmod 700 /etc/ssl/kamailio/privkey.pem

--- a/entrypoint
+++ b/entrypoint
@@ -17,14 +17,14 @@ sed -i -e "s/FILL_MY_WS_PORT/${MY_WS_PORT}/g" /etc/kamailio/kamailio.cfg
 sed -i -e "s/FILL_MY_WSS_PORT/${MY_WSS_PORT}/g" /etc/kamailio/kamailio.cfg
 
 # Allow disabling TLS by setting the TLS_DISABLE env variable to true
-if [ "$TLS_DISABLE" = true ]
+if [ "$TLS_DISABLE" = "true" ] || [ "$TLS_DISABLE" = "1" ]
 then
   sed -i -e "s/#!define WITH_TLS/##!define WITH_TLS/" /etc/kamailio/kamailio.cfg
 else
   chown 1501:1501 -R /etc/ssl/kamailio
-  chmod 655 -R /etc/ssl/kamailio
-  chmod 644 /etc/ssl/kamailio/fullchain.pem
-  chmod 600 /etc/ssl/kamailio/privkey.pem
+  chmod 755 -R /etc/ssl/kamailio
+  chmod 744 /etc/ssl/kamailio/fullchain.pem
+  chmod 700 /etc/ssl/kamailio/privkey.pem
 fi
 
 # shellcheck disable=SC2068

--- a/healthcheck
+++ b/healthcheck
@@ -1,0 +1,3 @@
+#!/bin/sh
+if ! supervisorctl status rtpengine | grep -q 'RUNNING'; then exit 1; fi
+if ! supervisorctl status kamailio | grep -q 'RUNNING'; then exit 1; fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-if ! supervisorctl status rtpengine | grep -q 'RUNNING'; then exit 1; fi
-if ! supervisorctl status kamailio | grep -q 'RUNNING'; then exit 1; fi


### PR DESCRIPTION
- Create rtpengine & kamailio users inside container.
- Apply ownership for config files and run directories properly.
- Convert entrypoint & healthcheck to POSIX scripts (best practice).
- Mount TLS certificates through directory instead of mounting the individual files.
- Allow overwriting the default Kamailio WebSocket ports.
- Improve supervisord configurations.
- Run rtpengine and kamailio as non-root.

AMD64 support has been tested in production on a Debian 12 host.
ARM64 support has been tested on QEMU, the container and the services successfully start up there.